### PR TITLE
Fix accessibility issue

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -18,7 +18,9 @@ $(function () {
     }
   });
 
-  $('#submit').click(function () {
+  $('form').on('submit', function (ev) {
+    ev.preventDefault();
+
     if (window.ga) {
       ga('send', 'event', 'Generate-button', 'Click');
     }

--- a/views/index.jade
+++ b/views/index.jade
@@ -12,9 +12,10 @@ block content
 
             p Saa käyttää, mutta ei oo pakko.
 
-            .form-group.pohina-form
-                label(for='name') Nimi:
-                input#name.form-control.input-lg(type="text", placeholder="Nimi")
+            form.pohina-form
+                .form-group
+                    label(for='name') Nimi:
+                    input#name.form-control.input-lg(type="text", placeholder="Nimi")
 
             .btn-container
                 button#submit.btn.btn-lg.btn-danger Generoi pöhinää!


### PR DESCRIPTION
Generation of pöhinä currently uses `onclick` event on the submit
button, instead of `onsubmit` event of the form which is the proper
method, as it allows the user to generate pöhinä by pressing enter on
the name input.